### PR TITLE
Return the String instead of URI object from the expiring_url method

### DIFF
--- a/lib/paperclip/storage/azure.rb
+++ b/lib/paperclip/storage/azure.rb
@@ -95,7 +95,7 @@ module Paperclip
             expiry:       (Time.now + time).utc.iso8601
           }
 
-          generator.signed_uri(uri, false, base_options.merge(azure_content_disposition))
+          generator.signed_uri(uri, false, base_options.merge(azure_content_disposition)).to_s
         else
           url(style_name)
         end


### PR DESCRIPTION
To the same behavior as using Amazon S3 with Paperclip.

Referred to this:
https://github.com/thoughtbot/paperclip/blob/v6.0.0/lib/paperclip/storage/s3.rb#L187